### PR TITLE
Promise.timeout() indicates time-out more precisely

### DIFF
--- a/src/com/codecatalyst/promise/Promise.as
+++ b/src/com/codecatalyst/promise/Promise.as
@@ -295,7 +295,7 @@ package com.codecatalyst.promise
 			{
 				timer.removeEventListener( TimerEvent.TIMER_COMPLETE, timerCompleteHandler );
 				
-				deferred.reject( new Error( "Promise timed out." ) );
+				deferred.reject( new TimeOutError() );
 			}
 			
 			var timer:Timer = new Timer( Math.max( milliseconds, 0 ), 1 );

--- a/src/com/codecatalyst/promise/TimeOutError.as
+++ b/src/com/codecatalyst/promise/TimeOutError.as
@@ -1,0 +1,12 @@
+
+package com.codecatalyst.promise
+{
+
+public class TimeOutError extends Error
+{
+  public function TimeOutError( message:String = null)
+  {
+    super( message ? message : "Promise timed out." );
+  }
+}
+}


### PR DESCRIPTION
When using Promise.timeout() you may want to differentiate between a promise time-out and other errors. To achive this I have added a TimeOutError class which Promise.timeout() use as rejection reason in case of a time-out.
