### PR TITLE
Change visibility of private class members

### DIFF
--- a/src/com/codecatalyst/promise/Consequence.as
+++ b/src/com/codecatalyst/promise/Consequence.as
@@ -205,17 +205,17 @@ class CallbackQueue
 	/**
 	 * Queued Callback(s).
 	 */
-	protected const queuedCallbacks:Array = new Array(1e4);
+	private const queuedCallbacks:Array = new Array(1e4);
 	
 	/**
 	 * Interval identifier.
 	 */
-	protected var intervalId:int = 0;
+	private var intervalId:int = 0;
 	
 	/**
 	 * # of pending callbacks.
 	 */
-	protected var queuedCallbackCount:uint = 0;
+	private var queuedCallbackCount:uint = 0;
 	
 	// ========================================
 	// Constructor
@@ -253,7 +253,7 @@ class CallbackQueue
 	/**
 	 * Execute any queued callbacks and clear the queue.
 	 */
-	protected function execute():void
+	private function execute():void
 	{
 		clearInterval( intervalId );
 		
@@ -283,12 +283,12 @@ class Callback
 	/**
 	 * Callback closure.
 	 */
-	protected var closure:Function;
+	private var closure:Function;
 	
 	/**
 	 * Callback parameters.
 	 */
-	protected var parameters:Array;
+	private var parameters:Array;
 	
 	// ========================================
 	// Constructor

--- a/src/com/codecatalyst/promise/adapter/AsyncTokenAdapter.as
+++ b/src/com/codecatalyst/promise/adapter/AsyncTokenAdapter.as
@@ -97,7 +97,7 @@ class DeferredResponder implements IResponder
 	// Constructor
 	// ========================================
 
-	function DeferredResponder()
+	public function DeferredResponder()
 	{
 		this.deferred = new Deferred();
 	}


### PR DESCRIPTION
Private class can't be extended from outside so protected visibility of its members doesn't make sense.
