### PR TITLE
Decrease default length of queuedCallbacks array

### DIFF
--- a/src/com/codecatalyst/promise/Consequence.as
+++ b/src/com/codecatalyst/promise/Consequence.as
@@ -205,7 +205,7 @@ class CallbackQueue
 	/**
 	 * Queued Callback(s).
 	 */
-	protected const queuedCallbacks:Array = new Array(1e4);
+	protected const queuedCallbacks:Array = new Array(200);
 	
 	/**
 	 * Interval identifier.


### PR DESCRIPTION
Is it really necessary to allocate memory for 1e4 elements?
