### PR TITLE
Making Prommises work with Mockolate by breaking circular dependency of Promise and Resolver

### DIFF
--- a/src/com/codecatalyst/promise/Promise.as
+++ b/src/com/codecatalyst/promise/Promise.as
@@ -593,6 +593,18 @@ package com.codecatalyst.promise
 			}
 		}
 		
+		/**
+		 * Creates a promise with a given resolver (breaks circular dependency when using Mocking)
+		 * 
+		 * @param resolver the instance of the resovler the promise is to use
+		 */
+		public static function create(resolver:Resolver) : Promise
+		{
+			var p : Promise = new Promise();
+			p.resolver = resolver;
+			return p;
+		}
+		
 		// ========================================
 		// Private static properties
 		// ========================================
@@ -620,9 +632,8 @@ package com.codecatalyst.promise
 		// Constructor
 		// ========================================
 		
-		public function Promise( resolver:Resolver )
-		{
-			this.resolver = resolver;	
+		public function Promise()
+		{	
 		}
 		
 		// ========================================

--- a/src/com/codecatalyst/promise/Resolver.as
+++ b/src/com/codecatalyst/promise/Resolver.as
@@ -103,7 +103,7 @@ package com.codecatalyst.promise
 		
 		public function Resolver()
 		{
-			this._promise = new Promise( this );
+			this._promise = Promise.create(this);
 			this.consequences = [];
 		}
 		


### PR DESCRIPTION
Promise and Resolver have a circular dependency which Mockolate / ASMock (Floxy) couldnt resolve.

This is in response to issue 27: https://github.com/CodeCatalyst/promise-as3/issues/27
